### PR TITLE
Utilise Strava's Best Effort Estimates

### DIFF
--- a/api/activities.go
+++ b/api/activities.go
@@ -1,8 +1,11 @@
 package api
 
 // Copied from https://github.com/strava/go.strava/blob/99ebe972ba16ef3e1b1e5f62003dae3ac06f3adb/activities.go
-// so that we were able to add WorkoutType into ActivitySummary struct.
-// workout_type is documented attribute in Strava API v3, but for some reason it is missing from go.strava
+// so that we were able to add SportType and WorkoutType into ActivitySummary struct.
+// sport_type and workout_type are documented attributes in Strava API v3,
+// but for some reason it is missing from go.strava
+// sport_type is string value that can be same as type or something newer. Known exceptions
+// - sport_type: TrailRun has type: Run
 // workout_type is integer value that needs separate transformation into string.
 import (
 	"fmt"
@@ -77,4 +80,9 @@ func (as *ActivitySummary) WorkoutType() string {
 		return options[as.WorkoutTypeId]
 	}
 	return fmt.Sprintf("Unknown (%d)", as.WorkoutTypeId)
+}
+
+func NewActivitiesService(client *Client) *strava.ActivitiesService {
+	stravaClient := strava.NewClient(client.token, client.httpClient)
+	return strava.NewActivitiesService(stravaClient)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	strava "github.com/strava/go.strava"
 )
 
 type Config struct {
@@ -83,7 +85,25 @@ func (cfg *Config) Refresh() (*Config, bool, error) {
 	return &tokens, true, nil
 }
 
-func ReadJSONs(fnames []string) ([]ActivitySummary, error) {
+func ReadBestEffortJSONs(fnames []string) ([]strava.BestEffort, error) {
+	efforts := []strava.BestEffort{}
+	for _, fname := range fnames {
+		body, err := os.ReadFile(filepath.Clean(fname))
+		if err != nil {
+			return efforts, err
+		}
+		activity := strava.ActivityDetailed{}
+		if err = json.Unmarshal(body, &activity); err != nil {
+			return efforts, err
+		}
+		for _, be := range activity.BestEfforts {
+			efforts = append(efforts, *be)
+		}
+	}
+	return efforts, nil
+}
+
+func ReadSummaryJSONs(fnames []string) ([]ActivitySummary, error) {
 	ids := map[int64]string{}
 	activities := []ActivitySummary{}
 	for _, fname := range fnames {

--- a/cmd/best.go
+++ b/cmd/best.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/cobra"
+
+	"github.com/jylitalo/mystats/pkg/stats"
+)
+
+// topCmd turns sqlite db into table or csv by week/month/...
+func bestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "best",
+		Short: "Best Run Efforts based on Strava",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			format, _ := flags.GetString("format")
+			limit, _ := flags.GetInt("limit")
+			distance, _ := flags.GetString("distance")
+			update, _ := flags.GetBool("update")
+			formatFn := map[string]func(headers []string, results [][]string){
+				"csv":   printTopCSV,
+				"table": printTopTable,
+			}
+			if _, ok := formatFn[format]; !ok {
+				return fmt.Errorf("unknown format: %s", format)
+			}
+			db, err := makeDB(update)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			headers, results, err := stats.Best(db, distance, limit)
+			if err != nil {
+				return err
+			}
+			formatFn[format](headers, results)
+			return nil
+		},
+	}
+	cmd.Flags().String("format", "csv", "output format (csv, table)")
+	cmd.Flags().String("distance", "Marathon", "Best Efforts distance")
+	cmd.Flags().Int("limit", 10, "number of entries")
+	cmd.Flags().Bool("update", true, "update database")
+	return cmd
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -16,7 +16,7 @@ func Execute() error {
 	}
 	rootCmd.AddCommand(
 		configureCmd(), fetchCmd(), makeCmd(),
-		listCmd(types), plotCmd(types), statsCmd(types), topCmd(types),
+		bestCmd(), listCmd(types), plotCmd(types), statsCmd(types), topCmd(types),
 		serverCmd(types),
 	)
 	return rootCmd.Execute()

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -2,15 +2,21 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jylitalo/mystats/api"
 	"github.com/jylitalo/mystats/config"
+	"github.com/jylitalo/mystats/storage"
 )
 
 // fetchCmd fetches activity data from Strava
@@ -19,23 +25,115 @@ func fetchCmd() *cobra.Command {
 		Use:   "fetch",
 		Short: "Fetch activity data from Strava to JSON files",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fetch()
+			flags := cmd.Flags()
+			be, _ := flags.GetBool("best_efforts")
+			return fetch(be)
 		},
 	}
+	cmd.Flags().Bool("best_efforts", false, "Fetch activities best efforts")
 	return cmd
 }
 
-func fetch() error {
+func fetch(best_efforts bool) error {
 	after, prior, err := getEpoch()
 	if err != nil {
 		return err
 	}
-	call, err := callListActivities(after)
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+	call, err := callListActivities(client, after)
 	if err != nil {
 		return err
 	}
 	_, err = saveActivities(call, prior)
+	if err == nil && best_efforts {
+		return fetchBestEfforts(client)
+	}
 	return err
+}
+
+func getClient() (*api.Client, error) {
+	cfg, err := config.Get(true)
+	if err != nil {
+		return nil, err
+	}
+	strava := cfg.Strava
+	api.ClientId = strava.ClientID
+	api.ClientSecret = strava.ClientSecret
+	client := api.NewClient(strava.AccessToken)
+	return client, err
+}
+
+func fetchBestEfforts(client *api.Client) error {
+	db := &storage.Sqlite3{}
+	if err := db.Open(); err != nil {
+		return err
+	}
+	rows, err := db.QuerySummary(
+		[]string{"StravaID"},
+		storage.SummaryConditions{Types: []string{"Run"}},
+		&storage.Order{OrderBy: []string{"StravaID desc"}},
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	stravaIDs := []int64{}
+	for rows.Next() {
+		var stravaID int64
+		err = rows.Scan(&stravaID)
+		if err != nil {
+			return err
+		}
+		stravaIDs = append(stravaIDs, stravaID)
+	}
+	if len(stravaIDs) < 1 {
+		return errors.New("no stravaIDs found from database")
+	}
+	fetched := 0
+	_ = os.Mkdir("activities", 0750)
+	actFiles, err := activitiesFiles()
+	if err != nil {
+		return err
+	}
+	alreadyFetched := []int64{}
+	for _, actFile := range actFiles {
+		intStr := strings.Split(strings.Split(actFile, "_")[1], ".")[0]
+		i, _ := strconv.Atoi(intStr)
+		alreadyFetched = append(alreadyFetched, int64(i))
+	}
+	service := api.NewActivitiesService(client)
+	for idx, stravaID := range stravaIDs {
+		if slices.Contains[[]int64, int64](alreadyFetched, stravaID) {
+			continue
+		}
+		call := service.Get(stravaID)
+		activity, err := call.Do()
+		if err != nil {
+			return err
+		}
+		j, err := json.Marshal(activity)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%d => activities/activity_%d.json ...\n", stravaID, stravaID)
+		if err = os.WriteFile(fmt.Sprintf("activities/activity_%d.json", stravaID), j, 0600); err != nil {
+			return err
+		}
+		fetched++
+		if fetched >= 100 {
+			slog.Info("Already fetched 100 activities", "left", len(stravaIDs)-idx)
+			return nil
+		}
+	}
+	slog.Info("Activity details fetched", "fetched", fetched)
+	return err
+}
+
+func activitiesFiles() ([]string, error) {
+	return filepath.Glob("activities/activity_*.json")
 }
 
 func pageFiles() ([]string, error) {
@@ -56,7 +154,7 @@ func getEpoch() (time.Time, int, error) {
 		}
 	}
 	offset := len(fnames)
-	activities, err := api.ReadJSONs(fnames)
+	activities, err := api.ReadSummaryJSONs(fnames)
 	if err != nil {
 		return epoch, offset, err
 	}
@@ -68,15 +166,7 @@ func getEpoch() (time.Time, int, error) {
 	return epoch, offset, nil
 }
 
-func callListActivities(after time.Time) (*api.CurrentAthleteListActivitiesCall, error) {
-	cfg, err := config.Get(true)
-	if err != nil {
-		return nil, err
-	}
-	strava := cfg.Strava
-	api.ClientId = strava.ClientID
-	api.ClientSecret = strava.ClientSecret
-	client := api.NewClient(strava.AccessToken)
+func callListActivities(client *api.Client, after time.Time) (*api.CurrentAthleteListActivitiesCall, error) {
 	current := api.NewCurrentAthleteService(client)
 	call := current.ListActivities()
 	return call.After(int(after.Unix())), nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,6 +17,7 @@ func listCmd(types []string) *cobra.Command {
 		Short: "List races or long runs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
+			limit, _ := flags.GetInt("limit")
 			types, _ := flags.GetStringSlice("type")
 			update, _ := flags.GetBool("update")
 			workouts, _ := flags.GetStringSlice("workout")
@@ -26,7 +27,7 @@ func listCmd(types []string) *cobra.Command {
 			}
 			defer db.Close()
 			table := tablewriter.NewWriter(os.Stdout)
-			headers, results, err := stats.List(db, types, workouts, nil)
+			headers, results, err := stats.List(db, types, workouts, nil, limit)
 			if err != nil {
 				return err
 			}
@@ -36,6 +37,7 @@ func listCmd(types []string) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().Int("limit", 100, "number of activities")
 	cmd.Flags().StringSlice("type", types, "sport types (run, trail run, ...)")
 	cmd.Flags().Bool("update", true, "update database")
 	cmd.Flags().StringSlice("workout", []string{}, "workout type")

--- a/pkg/plot/plot.go
+++ b/pkg/plot/plot.go
@@ -16,13 +16,15 @@ import (
 )
 
 type Storage interface {
-	Query(fields []string, cond storage.Conditions, order *storage.Order) (*sql.Rows, error)
-	QueryYears(cond storage.Conditions) ([]int, error)
+	QuerySummary(fields []string, cond storage.SummaryConditions, order *storage.Order) (*sql.Rows, error)
+	QueryYears(cond storage.SummaryConditions) ([]int, error)
 }
 
 func Plot(db Storage, types, workoutTypes []string, measurement string, month, day int, years []int, filename string) error {
 	tz, _ := time.LoadLocation("Europe/Helsinki")
-	cond := storage.Conditions{Types: types, WorkoutTypes: workoutTypes, Month: month, Day: day, Years: years}
+	cond := storage.SummaryConditions{
+		Types: types, WorkoutTypes: workoutTypes, Month: month, Day: day, Years: years,
+	}
 	years, err := db.QueryYears(cond)
 	if err != nil {
 		return err
@@ -36,7 +38,7 @@ func Plot(db Storage, types, workoutTypes []string, measurement string, month, d
 		totals[year] = 0
 	}
 	o := []string{"year", "month", "day"}
-	rows, err := db.Query(
+	rows, err := db.QuerySummary(
 		[]string{"year", "month", "day", "sum(" + measurement + ")"},
 		cond, &storage.Order{GroupBy: o, OrderBy: o},
 	)

--- a/pkg/stats/best.go
+++ b/pkg/stats/best.go
@@ -10,7 +10,7 @@ func Best(db Storage, distance string, limit int) ([]string, [][]string, error) 
 	o := []string{"besteffort.movingtime", "year", "month", "day"}
 	rows, err := db.QueryBestEffort(
 		[]string{
-			"year", "month", "day", "summary.name",
+			"year", "month", "day", "summary.name", "summary.distance",
 			"besteffort.movingtime", "besteffort.elapsedtime",
 			"summary.StravaID",
 		},
@@ -23,16 +23,18 @@ func Best(db Storage, distance string, limit int) ([]string, [][]string, error) 
 	results := [][]string{}
 	for rows.Next() {
 		var year, month, day, movingTime, elapsedTime, stravaID int
+		var distance float64
 		var name string
-		err = rows.Scan(&year, &month, &day, &name, &movingTime, &elapsedTime, &stravaID)
+		err = rows.Scan(&year, &month, &day, &name, &distance, &movingTime, &elapsedTime, &stravaID)
 		if err != nil {
 			return nil, nil, err
 		}
 		results = append(results, []string{
 			fmt.Sprintf("%2d.%2d.%d", day, month, year), name,
 			fmt.Sprintf("%2d:%02d:%02d", elapsedTime/3600, elapsedTime/60%60, elapsedTime%60),
+			fmt.Sprintf("%.2f", distance/1000),
 			fmt.Sprintf("https://strava.com/activities/%d", stravaID),
 		})
 	}
-	return []string{"Date", distance, "Time", "Link"}, results, nil
+	return []string{"Date", distance, "Time", "Total (km)", "Link"}, results, nil
 }

--- a/pkg/stats/best.go
+++ b/pkg/stats/best.go
@@ -1,0 +1,38 @@
+package stats
+
+import (
+	"fmt"
+
+	"github.com/jylitalo/mystats/storage"
+)
+
+func Best(db Storage, distance string, limit int) ([]string, [][]string, error) {
+	o := []string{"besteffort.movingtime", "year", "month", "day"}
+	rows, err := db.QueryBestEffort(
+		[]string{
+			"year", "month", "day", "summary.name",
+			"besteffort.movingtime", "besteffort.elapsedtime",
+			"summary.StravaID",
+		},
+		distance, &storage.Order{OrderBy: o, Limit: limit},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("query caused: %w", err)
+	}
+	defer rows.Close()
+	results := [][]string{}
+	for rows.Next() {
+		var year, month, day, movingTime, elapsedTime, stravaID int
+		var name string
+		err = rows.Scan(&year, &month, &day, &name, &movingTime, &elapsedTime, &stravaID)
+		if err != nil {
+			return nil, nil, err
+		}
+		results = append(results, []string{
+			fmt.Sprintf("%2d.%2d.%d", day, month, year), name,
+			fmt.Sprintf("%2d:%02d:%02d", elapsedTime/3600, elapsedTime/60%60, elapsedTime%60),
+			fmt.Sprintf("https://strava.com/activities/%d", stravaID),
+		})
+	}
+	return []string{"Date", distance, "Time", "Link"}, results, nil
+}

--- a/pkg/stats/list.go
+++ b/pkg/stats/list.go
@@ -7,12 +7,12 @@ import (
 	"github.com/jylitalo/mystats/storage"
 )
 
-func List(db Storage, types, workouts []string, years []int) ([]string, [][]string, error) {
+func List(db Storage, types, workouts []string, years []int, limit int) ([]string, [][]string, error) {
 	o := []string{"year", "month", "day"}
 	rows, err := db.QuerySummary(
 		[]string{"year", "month", "day", "name", "distance", "elevation", "movingtime", "type", "workouttype", "stravaid"},
 		storage.SummaryConditions{WorkoutTypes: workouts, Types: types, Years: years},
-		&storage.Order{GroupBy: o, OrderBy: o},
+		&storage.Order{GroupBy: o, OrderBy: o, Limit: limit},
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("query caused: %w", err)

--- a/pkg/stats/list.go
+++ b/pkg/stats/list.go
@@ -9,9 +9,9 @@ import (
 
 func List(db Storage, types, workouts []string, years []int) ([]string, [][]string, error) {
 	o := []string{"year", "month", "day"}
-	rows, err := db.Query(
+	rows, err := db.QuerySummary(
 		[]string{"year", "month", "day", "name", "distance", "elevation", "movingtime", "type", "workouttype", "stravaid"},
-		storage.Conditions{WorkoutTypes: workouts, Types: types, Years: years},
+		storage.SummaryConditions{WorkoutTypes: workouts, Types: types, Years: years},
 		&storage.Order{GroupBy: o, OrderBy: o},
 	)
 	if err != nil {

--- a/pkg/stats/top.go
+++ b/pkg/stats/top.go
@@ -10,9 +10,9 @@ import (
 
 func Top(db Storage, measurement, period string, types, workoutTypes []string, limit int, years []int) ([]string, [][]string, error) {
 	results := [][]string{}
-	rows, err := db.Query(
+	rows, err := db.QuerySummary(
 		[]string{measurement + " as total", "year", period},
-		storage.Conditions{Types: types, WorkoutTypes: workoutTypes, Years: years},
+		storage.SummaryConditions{Types: types, WorkoutTypes: workoutTypes, Years: years},
 		&storage.Order{
 			GroupBy: []string{"year", period},
 			OrderBy: []string{"total desc", "year desc", period + " desc"},

--- a/server/best.go
+++ b/server/best.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"errors"
+	"log"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	"github.com/jylitalo/mystats/pkg/stats"
+	"github.com/labstack/echo/v4"
+)
+
+type BestFormData struct {
+	Distances map[string]bool
+}
+
+func newBestFormData() BestFormData {
+	return BestFormData{
+		Distances: map[string]bool{},
+	}
+}
+
+type BestData struct {
+	Data []TableData
+}
+
+func newBestData() BestData {
+	return BestData{
+		Data: []TableData{},
+	}
+}
+
+type BestPage struct {
+	Form BestFormData
+	Data BestData
+}
+
+func newBestPage() *BestPage {
+	return &BestPage{
+		Form: newBestFormData(),
+		Data: newBestData(),
+	}
+}
+
+func selectedBestEfforts(distances map[string]bool) []string {
+	checked := []string{}
+	for k, v := range distances {
+		if v {
+			checked = append(checked, k)
+		}
+	}
+	return checked
+}
+
+func bestEffortValues(values url.Values) (map[string]bool, error) {
+	if values == nil {
+		return nil, errors.New("no bename values given")
+	}
+	bestEfforts := map[string]bool{}
+	for k, v := range values {
+		if strings.HasPrefix(k, "be_") {
+			tv := strings.ReplaceAll(strings.ReplaceAll(k[3:], "_", " "), "X", "/")
+			bestEfforts[tv] = (len(tv) > 0 && v[0] == "on")
+		}
+	}
+	return bestEfforts, nil
+}
+
+func bestPost(page *Page, db Storage) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		var err error
+
+		values, errV := c.FormParams()
+		bestEfforts, errB := bestEffortValues(values)
+		if err = errors.Join(errV, errB); err != nil {
+			log.Fatal(err)
+		}
+		slog.Info("POST /best", "values", values)
+		page.Best.Form.Distances = bestEfforts
+		page.Best.Data = newBestData()
+		for _, be := range selectedBestEfforts(bestEfforts) {
+			headers, rows, err := stats.Best(db, be, 3)
+			if err != nil {
+				return err
+			}
+			page.Best.Data.Data = append(page.Best.Data.Data, TableData{
+				Headers: headers,
+				Rows:    rows,
+			})
+		}
+		return errors.Join(err, c.Render(200, "best-data", page.Best.Data))
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -209,6 +209,7 @@ func Start(db Storage, selectedTypes []string, port int) error {
 		page.Top.Form.Years[y] = true
 	}
 	value := true
+	page.Best.Form.InOrder = bestEfforts
 	for _, be := range bestEfforts {
 		page.Best.Form.Distances[be] = value
 		value = false
@@ -233,7 +234,8 @@ func indexGet(page *Page, db Storage) func(c echo.Context) error {
 		types := selectedTypes(pf.Types)
 		workoutTypes := selectedWorkoutTypes(pf.WorkoutTypes)
 		years := selectedYears(pf.Years)
-		page.List.Data.Headers, page.List.Data.Rows, errL = stats.List(db, types, workoutTypes, years)
+		pld := &page.List.Data
+		pld.Headers, pld.Rows, errL = stats.List(db, types, workoutTypes, years, page.List.Form.Limit)
 		// init Top tab
 		tf := &page.Top.Form
 		td := &page.Top.Data

--- a/server/server.go
+++ b/server/server.go
@@ -19,10 +19,12 @@ import (
 )
 
 type Storage interface {
-	Query(fields []string, cond storage.Conditions, order *storage.Order) (*sql.Rows, error)
-	QueryTypes(cond storage.Conditions) ([]string, error)
-	QueryWorkoutTypes(cond storage.Conditions) ([]string, error)
-	QueryYears(cond storage.Conditions) ([]int, error)
+	QueryBestEffort(fields []string, name string, order *storage.Order) (*sql.Rows, error)
+	QueryBestEffortDistances() ([]string, error)
+	QuerySummary(fields []string, cond storage.SummaryConditions, order *storage.Order) (*sql.Rows, error)
+	QueryTypes(cond storage.SummaryConditions) ([]string, error)
+	QueryWorkoutTypes(cond storage.SummaryConditions) ([]string, error)
+	QueryYears(cond storage.SummaryConditions) ([]int, error)
 }
 
 type TableData struct {
@@ -39,6 +41,7 @@ func newTableData() TableData {
 
 type Page struct {
 	Plot *PlotPage
+	Best *BestPage
 	List *ListPage
 	Top  *TopPage
 }
@@ -46,6 +49,7 @@ type Page struct {
 func newPage() *Page {
 	return &Page{
 		Plot: newPlotPage(),
+		Best: newBestPage(),
 		List: newListPage(),
 		Top:  newTopPage(),
 	}
@@ -71,7 +75,7 @@ func newTemplate(path string) *Template {
 			return i - 1
 		},
 		"esc": func(s string) string {
-			return strings.ReplaceAll(s, " ", "_")
+			return strings.ReplaceAll(strings.ReplaceAll(s, " ", "_"), "/", "X")
 		},
 		"inc": func(i int) int {
 			return i + 1
@@ -84,7 +88,7 @@ func newTemplate(path string) *Template {
 		},
 	}
 	return &Template{
-		tmpl: template.Must(template.New("plot").Funcs(funcMap).ParseGlob(path)),
+		tmpl: template.Must(template.New("index").Funcs(funcMap).ParseGlob(path)),
 	}
 }
 
@@ -175,10 +179,11 @@ func Start(db Storage, selectedTypes []string, port int) error {
 	e.Static("/css", "server/css")
 
 	page := newPage()
-	types, errT := db.QueryTypes(storage.Conditions{})
-	workoutTypes, errW := db.QueryWorkoutTypes(storage.Conditions{})
-	years, errY := db.QueryYears(storage.Conditions{})
-	if err := errors.Join(errT, errW, errY); err != nil {
+	types, errT := db.QueryTypes(storage.SummaryConditions{})
+	workoutTypes, errW := db.QueryWorkoutTypes(storage.SummaryConditions{})
+	years, errY := db.QueryYears(storage.SummaryConditions{})
+	bestEfforts, errBE := db.QueryBestEffortDistances()
+	if err := errors.Join(errT, errW, errY, errBE); err != nil {
 		return err
 	}
 	// it is faster to first mark everything false and afterwards change selected one to true,
@@ -203,9 +208,15 @@ func Start(db Storage, selectedTypes []string, port int) error {
 		page.Plot.Form.Years[y] = true
 		page.Top.Form.Years[y] = true
 	}
+	value := true
+	for _, be := range bestEfforts {
+		page.Best.Form.Distances[be] = value
+		value = false
+	}
 	slog.Info("starting things", "page", page)
 
 	e.GET("/", indexGet(page, db))
+	e.POST("/best", bestPost(page, db))
 	e.POST("/list", listPost(page, db))
 	e.POST("/plot", plotPost(page, db))
 	e.POST("/top", topPost(page, db))
@@ -218,13 +229,26 @@ func indexGet(page *Page, db Storage) func(c echo.Context) error {
 		var errL, errT error
 		pf := &page.Plot.Form
 		errP := page.Plot.render(db, pf.Types, pf.WorkoutTypes, pf.EndMonth, pf.EndDay, pf.Years)
+		// init List tab
 		types := selectedTypes(pf.Types)
 		workoutTypes := selectedWorkoutTypes(pf.WorkoutTypes)
 		years := selectedYears(pf.Years)
 		page.List.Data.Headers, page.List.Data.Rows, errL = stats.List(db, types, workoutTypes, years)
+		// init Top tab
 		tf := &page.Top.Form
 		td := &page.Top.Data
 		td.Headers, td.Rows, errT = stats.Top(db, tf.measurement, tf.period, types, workoutTypes, tf.limit, years)
+		// init Best tab
+		for _, be := range selectedBestEfforts(page.Best.Form.Distances) {
+			headers, rows, err := stats.Best(db, be, 3)
+			if err != nil {
+				return err
+			}
+			page.Best.Data.Data = append(page.Best.Data.Data, TableData{
+				Headers: headers,
+				Rows:    rows,
+			})
+		}
 		return errors.Join(errP, errL, errT, c.Render(200, "index", page))
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -13,19 +13,27 @@ import (
 
 type testDB struct{}
 
-func (t *testDB) Query(fields []string, cond storage.Conditions, order *storage.Order) (*sql.Rows, error) {
+func (t *testDB) QueryBestEffort(fields []string, distance string, order *storage.Order) (*sql.Rows, error) {
 	return nil, nil
 }
 
-func (t *testDB) QueryTypes(cond storage.Conditions) ([]string, error) {
+func (t *testDB) QueryBestEffortDistances() ([]string, error) {
 	return nil, nil
 }
 
-func (t *testDB) QueryWorkoutTypes(cond storage.Conditions) ([]string, error) {
+func (t *testDB) QuerySummary(fields []string, cond storage.SummaryConditions, order *storage.Order) (*sql.Rows, error) {
 	return nil, nil
 }
 
-func (t *testDB) QueryYears(cond storage.Conditions) ([]int, error) {
+func (t *testDB) QueryTypes(cond storage.SummaryConditions) ([]string, error) {
+	return nil, nil
+}
+
+func (t *testDB) QueryWorkoutTypes(cond storage.SummaryConditions) ([]string, error) {
+	return nil, nil
+}
+
+func (t *testDB) QueryYears(cond storage.SummaryConditions) ([]int, error) {
 	return nil, nil
 }
 

--- a/server/views/best.html
+++ b/server/views/best.html
@@ -1,0 +1,55 @@
+{{ block "best-tab" . }}
+{{ template "best-form" .Form }}
+<hr />
+{{ template "best-data" .Data }}
+{{ end }}
+
+{{ block "best-form" . }}
+<form hx-swap="outerHTML" hx-target="#best-data" hx-post="/best">
+    <div id="limit">
+
+    </div>
+    {{ template "bename" . }}
+</form>
+{{ end }}
+
+{{ block "bename" . }}
+<div id="bename">
+    Best Efforts:
+    {{ range $b, $v := .Distances }}
+    <input type="checkbox" name="be_{{ esc $b }}"{{ if $v }} checked{{ end }} hx-swap="outerHTML" hx-target="#best-data" hx-post="/best"><label>{{ $b }}</label>
+    {{ end }}
+</div>
+{{ end }}
+
+{{ block "best-data" . }}
+<div id="best-data">
+    {{ range $table := .Data }}
+    <table>
+        <thead>
+            <tr>
+            {{ range $s := $table.Headers }}
+            <th>{{ $s }}</th>
+            {{ end }}
+        </tr>
+        </thead>
+        <tbody>
+            {{ range $row := $table.Rows }}
+                {{ $trimmed := joined $row }}
+                {{ if ne $trimmed "" }}
+                <tr>
+                    {{ range $idx, $col := $row }}
+                        {{ if eq $idx 3 }}
+                        <td><a href="{{ $col }}">{{ $col }}</a></td>
+                        {{ else }}
+                        <td{{ if eq $idx 1 }} class="name"{{ end }}>{{ $col }}</td>
+                        {{ end }}
+                    {{ end }}
+                </tr>
+                {{ end }}
+            {{ end }}
+        </tbody>
+    </table>
+    {{ end }}
+</div>
+{{ end }}

--- a/server/views/best.html
+++ b/server/views/best.html
@@ -6,17 +6,25 @@
 
 {{ block "best-form" . }}
 <form hx-swap="outerHTML" hx-target="#best-data" hx-post="/best">
-    <div id="limit">
-
-    </div>
     {{ template "bename" . }}
+    <div id="limit">
+        Items per distance:
+        <select name="limit" hx-swap="outerHTML" hx-target="#best-data" hx-post="/best">
+            <option {{ if eq .Limit 3 }} selected{{ end }}>3</option>
+            <option {{ if eq .Limit 5 }} selected{{ end }}>5</option>
+            <option {{ if eq .Limit 10 }} selected{{ end }}>10</option>
+            <option {{ if eq .Limit 100 }} selected{{ end }}>100</option>
+        </select>
+    </div>
 </form>
 {{ end }}
 
 {{ block "bename" . }}
 <div id="bename">
-    Best Efforts:
-    {{ range $b, $v := .Distances }}
+    Distances:
+    {{ $m := .Distances }}
+    {{ range $b := .InOrder }}
+    {{ $v := index $m $b }}
     <input type="checkbox" name="be_{{ esc $b }}"{{ if $v }} checked{{ end }} hx-swap="outerHTML" hx-target="#best-data" hx-post="/best"><label>{{ $b }}</label>
     {{ end }}
 </div>
@@ -39,7 +47,7 @@
                 {{ if ne $trimmed "" }}
                 <tr>
                     {{ range $idx, $col := $row }}
-                        {{ if eq $idx 3 }}
+                        {{ if eq $idx 4 }}
                         <td><a href="{{ $col }}">{{ $col }}</a></td>
                         {{ else }}
                         <td{{ if eq $idx 1 }} class="name"{{ end }}>{{ $col }}</td>

--- a/server/views/index.html
+++ b/server/views/index.html
@@ -11,11 +11,15 @@
     <body>
         <div class="tab">
             <button class="tablinks" onclick="openTab(event, 'Plot')" id="defaultOpen">Plot</button>
+            <button class="tablinks" onclick="openTab(event, 'Best')">Best Running Efforts</button>
             <button class="tablinks" onclick="openTab(event, 'List')">List</button>
             <button class="tablinks" onclick="openTab(event, 'Top')">Top</button>
         </div>
         <div id="Plot" class="tabcontent">
             {{ template "plot-tab" .Plot }}
+        </div>
+        <div id="Best" class="tabcontent">
+            {{ template "best-tab" .Best }}
         </div>
         <div id="List" class="tabcontent">
             {{ template "list-tab" .List }}
@@ -76,7 +80,6 @@
 <div id="years">
     Years:
     {{ range $y, $v := .Years }}
-        <input type="checkbox" name="year_{{ $y }}"{{ if $v }} checked{{ end }} hx-swap="outerHTML" hx-target="#{{ $name }}-data" hx-post="/{{ $name }}"><label>{{ $y }}</label>
-    {{ end }}
+        <input type="checkbox" name="year_{{ $y }}"{{ if $v }} checked{{ end }} hx-swap="outerHTML" hx-target="#{{ $name }}-data" hx-post="/{{ $name }}"><label>{{ $y }}</label>    {{ end }}
 </div>
 {{ end }}

--- a/server/views/list.html
+++ b/server/views/list.html
@@ -6,12 +6,17 @@
 
 {{ block "list-form" . }}
 <form hx-swap="outerHTML" hx-target="#list-data" hx-post="/list">
-    <div id="limit">
-
-    </div>
     {{ template "types" . }}
     {{ template "workouttypes" . }}
     {{ template "years" . }}
+    <div id="limit">
+        Number of activities:
+        <select name="limit" hx-swap="outerHTML" hx-target="#list-data" hx-post="/list">
+            <option{{ if eq .Limit 10 }} selected{{ end }}>10</option>
+            <option{{ if eq .Limit 20 }} selected{{ end }}>20</option>
+            <option{{ if eq .Limit 100 }} selected{{ end }}>100</option>
+        </select>
+    </div>
 </form>
 {{ end }}
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -5,30 +5,56 @@ import "testing"
 func TestSqlQuery(t *testing.T) {
 	values := []struct {
 		name   string
+		tables []string
 		fields []string
-		cond   Conditions
+		cond   conditions
 		order  *Order
 		query  string
 	}{
-		{"none", []string{"field"}, Conditions{}, nil, "select field from mystats"},
-		{"simple", []string{"field"}, Conditions{Types: []string{"Run"}}, nil, "select field from mystats where (type='Run')"},
 		{
-			"multi-field", []string{"f1", "f2"},
-			Conditions{Types: []string{"r1", "r2"}},
+			"none", []string{"summary"}, []string{"field"}, conditions{}, nil,
+			"select field from summary"},
+		{
+			"simple", []string{"summary"}, []string{"field"}, conditions{Types: []string{"Run"}}, nil,
+			"select field from summary where (type='Run')",
+		},
+		{
+			"multi-field", []string{"summary"}, []string{"f1", "f2"},
+			conditions{Types: []string{"r1", "r2"}},
 			&Order{GroupBy: []string{"f3"}, OrderBy: []string{"f3 desc"}},
-			"select f1,f2 from mystats where (type='r1' or type='r2') group by f3 order by f3 desc",
+			"select f1,f2 from summary where (type='r1' or type='r2') group by f3 order by f3 desc",
 		},
 		{
-			"order", []string{"k1", "k2"}, Conditions{Types: []string{"c1"}, WorkoutTypes: []string{"c3"}},
+			"order", []string{"summary"}, []string{"k1", "k2"},
+			conditions{Types: []string{"c1"}, WorkoutTypes: []string{"c3"}},
 			&Order{GroupBy: []string{"k3", "k4"}, OrderBy: []string{"k5", "k6"}, Limit: 7},
-			"select k1,k2 from mystats where (workouttype='c3') and (type='c1') group by k3,k4 order by k5,k6 limit 7",
+			"select k1,k2 from summary where (workouttype='c3') and (type='c1') group by k3,k4 order by k5,k6 limit 7",
 		},
-		{"one_year", []string{"field"}, Conditions{Types: []string{"Run"}, Years: []int{2023}}, nil, "select field from mystats where (type='Run') and (year=2023)"},
-		{"multiple_years", []string{"field"}, Conditions{Types: []string{"Run"}, Years: []int{2019, 2023}}, nil, "select field from mystats where (type='Run') and (year=2019 or year=2023)"},
+		{
+			"one_year", []string{"summary"}, []string{"field"},
+			conditions{Types: []string{"Run"}, Years: []int{2023}}, nil,
+			"select field from summary where (type='Run') and (year=2023)",
+		},
+		{
+			"multiple_years", []string{"summary"}, []string{"field"},
+			conditions{Types: []string{"Run"}, Years: []int{2019, 2023}}, nil,
+			"select field from summary where (type='Run') and (year=2019 or year=2023)",
+		},
+		{
+			"ids", []string{"summary"},
+			[]string{"StravaID"},
+			conditions{Types: []string{"Run"}},
+			&Order{OrderBy: []string{"StravaID desc"}},
+			"select StravaID from summary where (type='Run') order by StravaID desc",
+		},
+		{
+			"besteffort", []string{"summary", "besteffort"}, []string{"summary.Name"}, conditions{BEName: "400m"}, nil,
+			"select summary.Name from summary,besteffort where summary.StravaID=besteffort.StravaID and besteffort.name='400m'",
+		},
 	}
 	for _, value := range values {
 		t.Run(value.name, func(t *testing.T) {
-			cmd := sqlQuery(value.fields, value.cond, value.order)
+			cmd := sqlQuery(value.tables, value.fields, value.cond, value.order)
 			if cmd != value.query {
 				t.Errorf("mismatch got '%s' vs. expected '%s'", cmd, value.query)
 			}


### PR DESCRIPTION
Strava calculates athlete's best 400m, 1/2 mile, 1K, ... stats from running activities. It only gives limited how those best efforts rank between different activities on the website, but you can fetch all that data in small chunks via Strava API and do the processing on your own.

While we can fetch summary of athlete's activities with decent number of API calls, best effort estimates have to be requested separately for each activity and this quickly becomes problem with Strava's rate limits ( https://developers.strava.com/docs/rate-limits/ ). For this reason, we once again store data as JSON in local files before we start making any sqlite database entries out of it.

On database end, this forced us to create second table into database and so I ended up renaming former `mystats` table into `summary` and introduce new Best Effort table.

On CLI, the best efforts information is available via `mystats best` command. Web UI got new 'Best Running Efforts' tab for web presentation of data.